### PR TITLE
fix: Safari browser action icon color

### DIFF
--- a/src/background/functions/setIcon.js
+++ b/src/background/functions/setIcon.js
@@ -45,7 +45,9 @@ const setIcon = async (tabId, active = true, changeTitle = false) => {
   const iconTitle = active ? '2FAS - Two Factor Authentication' : browser.i18n.getMessage('inActiveTabInfo');
 
   if (process.env.EXT_PLATFORM === 'Firefox' || process.env.EXT_PLATFORM === 'Safari') {
-    browser.browserAction.setIcon(iconObj);
+    if (process.env.EXT_PLATFORM === 'Firefox') {
+      browser.browserAction.setIcon(iconObj);
+    }
 
     if (active || (!active && changeTitle)) {
       await browser.browserAction.setTitle({ tabId, title: iconTitle });


### PR DESCRIPTION

![image](https://github.com/twofas/2fas-browser-extension/assets/829098/da391e9e-4250-4db6-b69e-17e5672c5d49)

On Safari, the icon should not be changed (at least not to change between colored and greyscale). 
When the extension is not active, Safari will automatically generate a greyscale representation based on the colored icon. 

It's still strange to see blue, because that means Safari detected the extension to be inactive and since a gray icon is present, it then applies the systems highlight color to it. So I suspect there is another bug in play which is not correctly setting the 'active' state.

---

This is untested! See https://github.com/twofas/2fas-browser-extension/issues/9