### PR TITLE
fix: add passwordSelectors for IBM Cloud 2FA

### DIFF
--- a/src/partials/inputsSelectors.js
+++ b/src/partials/inputsSelectors.js
@@ -43,7 +43,8 @@ const inputsSelectors = () => {
   const passwordSelectors = [
     'input[type="password"]#security-code', // OneLogin
     'input#mfacode', // AWS
-    'input[type="password"]#challenge' // AWS
+    'input[type="password"]#challenge', // AWS
+    'input[type="password"]#otp' // IBM Cloud
   ].join(',');
 
   const textAreaSelectors = [


### PR DESCRIPTION
The IBM Cloud 2FA page uses a `password` type that prevents the extension from using the field to trigger a 2FA request.

Currently the extension throws a `warningSelectInputTitle` whenever you attempt to trigger it.

Link: https://cloud.ibm.com/login

Element:
```
<input class="bx--text-input" id="otp" type="password" pattern="[0-9]*" inputmode="numeric" maxlength="6" size="15" name="otp">
```

![Screenshot 2024-02-26 at 17 14 52](https://github.com/twofas/2fas-browser-extension/assets/23284299/f0cd708c-a862-4786-88fd-ee490df3373e)
