### PR TITLE
Add GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -28,7 +28,7 @@ body:
     attributes:
       label: Website
       description: If applicable, link the page where the issue occurs.
-      placeholder: e.g. `https://github.com/login`
+      placeholder: e.g. https://github.com/login
   - type: textarea
     attributes:
       label: Bug description

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,63 @@
+name: 🐞 Bug report
+description: Report a bug or issue.
+title: 'bug: '
+labels: ['Bug']
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Before creating a bug report, please keep the following in mind:
+
+        - Do not submit a duplicate bug report. You can review existing bug reports [here](https://github.com/twofas/2fas-browser-extension/labels/Bug).
+        - Security vulnerabilities should be reported to security@2fas.com.
+  - type: textarea
+    attributes:
+      label: Browser info
+      description: Write down the browser and version in which the bug occurs.
+      placeholder: e.g. Chrome (Windows) version 122.0.6261.70
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Browser extension version
+      description: Write down the browser extension version in which the bug occurs.
+      placeholder: e.g. 1.6.2
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Website
+      description: If applicable, link the page where the issue occurs.
+      placeholder: e.g. `https://github.com/login`
+  - type: textarea
+    attributes:
+      label: Bug description
+      description: |
+        - Describe your bug in detail
+        - Add steps to reproduce the bug if possible (Step 1. ... Step 2. ...)
+        - Add images or videos if necessary
+    validations:
+        required: true
+  - type: textarea
+    attributes:
+      label: Solution
+      description: If applicable, add a possible solution to the bug.
+  - type: textarea
+    attributes:
+      label: Additional context
+      description: Add additional context here if necessary.
+  - type: checkboxes
+    id: acknowledgements
+    attributes:
+      label: Acknowledgements
+      description: Your bug report will be closed if you don't follow the checklist below.
+      options:
+        - label: This issue is not a duplicate of an existing bug report.
+          required: true
+        - label: I understand that security vulnerabilities should be reported to security@2fas.com instead of on GitHub.
+          required: true
+        - label: I have chosen an appropriate title.
+          required: true
+        - label: All requested information has been provided properly.
+          required: true
+  

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Help center
+    url: https://2fas.com/help-center/
+    about: Check out our extensive FaQ and video guides!
+  - name: Discord
+    url: https://discord.gg/q4cP6qh2g5
+    about: Need support or have a question? Our Discord members are there to help!
+  - name: Reddit
+    url: https://www.reddit.com/r/2fas_com/
+    about: Get support and discuss 2FAS with our Reddit community!

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,0 +1,35 @@
+name: ⭐ Feature request
+description: Request a feature or enhancement.
+title: 'feat: '
+labels: ['Feature']
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Before creating a feature request, please ensure that it is not a duplicate of an existing feature request. You can review existing feature requests [here](https://github.com/twofas/2fas-browser-extension/labels/Feature).
+  - type: textarea
+    attributes:
+      label: Feature description
+      description: |
+        - Describe the feature in detail
+        - Add images, videos, links, examples, etc. if necessary
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Motivation
+      description: Why should this feature be implemented?
+    validations:
+      required: true
+  - type: checkboxes
+    id: acknowledgements
+    attributes:
+      label: Acknowledgements
+      description: Your feature request will be closed if you don't follow the checklist below.
+      options:
+        - label: This issue is not a duplicate of an existing feature request.
+          required: true
+        - label: I have chosen an appropriate title.
+          required: true
+        - label: All requested information has been provided properly.
+          required: true


### PR DESCRIPTION
This PR adds options to the [issue creation page](https://github.com/twofas/2fas-browser-extension/issues/new/choose) with links to the FaQ on the website, Discord server, and subreddit.

It also adds a bug report and feature request form. I should probably also make a "Question" form. LMK if you want that. 

