### PR TITLE
inputToken.js - fix for Fortra GoAnywhere

### DIFF
--- a/src/content/functions/inputToken.js
+++ b/src/content/functions/inputToken.js
@@ -62,6 +62,12 @@ const inputToken = (request, inputElement, siteURL) => {
           document.activeElement.value += request.token[i];
           document.activeElement.dispatchEvent(inputEvent);
 
+          // FORTRA GOANYWHERE FIX
+          if (siteURL.includes('.goanywhere.cloud') {
+            document.getElementById('formPanel:answer_hinput').value = request.token;
+          }
+          // FORTRA GOANYWHERE FIX
+          
           // NORTON FIX
           if (siteURL.includes('login.norton') || siteURL.includes('indodax.com')) {
             document.activeElement.dispatchEvent(new KeyboardEvent('keyup', { key: request.token[i] }));


### PR DESCRIPTION
This site uses a hidden input field for actual MFA token submission, while the visible input field presents as a password field with masked input (but isn't actually of type "password").

I made a simple fix that doesn't incorporate delays and "typing action" because I didn't want to change too many lines. Let me know if you'd like an approach that retains these techniques, and I'll submit a new request.